### PR TITLE
Update gitignore to ignore vagrant artefacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
 
+.vagrant
+Vagrantfile
+
 # Package Files #
 # *.jar #
 *.war


### PR DESCRIPTION
For users using virtual machines w/vagrant we don't want the .vagrant folder included (nor YET) the Vagrantfile.
